### PR TITLE
feat: add --column and --exclude-column CLI options

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.5.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name="datacomp",
-    version="0.4.0",
+    version="0.5.0",
     description="CLI for comparing tabular data files",
     author="kappamaki",
     install_requires=["pandas", "pyarrow"],


### PR DESCRIPTION
- handle pandas metadata by resetting the index when loading files
- load files in "main" function (expect dataframes as input for
  compare_data function)
- clean up duplicate function definition