### PR TITLE
fix: do not try to output numeric stats for bool columns

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.6.1
 commit = True
 tag = True
 

--- a/datacomp/compare.py
+++ b/datacomp/compare.py
@@ -163,6 +163,8 @@ def compare_data(df1: pd.DataFrame, df2: pd.DataFrame, index_cols: List[str]) ->
                 if (
                     pd.api.types.is_numeric_dtype(df1[col].dtype)
                     and pd.api.types.is_numeric_dtype(df2[col].dtype)
+                    and not pd.api.types.is_bool_dtype(df1[col].dtype)
+                    and not pd.api.types.is_bool_dtype(df2[col].dtype)
                 ):
                     abs_diff = (df1[col] - df2[col]).abs()
                     result.column_results[col].diff_min = abs_diff.min()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name="datacomp",
-    version="0.6.0",
+    version="0.6.1",
     description="CLI for comparing tabular data files",
     author="kappamaki",
     install_requires=["pandas", "pyarrow"],


### PR DESCRIPTION
- pandas things a bool is a numeric type
- can't produce stats like mean/max/absolute diff for bool data